### PR TITLE
#2467 broken link in projectcalico/app-policy's README

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ processed.  We compute policy based on a global store which is distributed to Di
 Application Layer Policy is described in the [Project Calico docs][docs].
 
  - [Enabling Application Layer Policy](https://docs.projectcalico.org/master/getting-started/kubernetes/installation/app-layer-policy)
- - [Application Layer Policy Tutorial](https://docs.projectcalico.org/master/getting-started/kubernetes/tutorials/app-layer-policy/)
+ - [Application Layer Policy Tutorial](https://docs.projectcalico.org/latest/security/app-layer-policy/)
  
  
  [calico]: https://projectcalico.org


### PR DESCRIPTION
Just fixing the link at the end of the README that points to the app layer policy tutorial.
